### PR TITLE
Lifecycle prevent destroying MSK clusters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,10 @@ resource "aws_msk_cluster" "this" {
     }
   }
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   tags = merge(map("Name", local.cluster_name), var.msk_cluster_tags, var.tags)
 }
 


### PR DESCRIPTION
Add the TF metadata argument to prevent destroying the MSK cluster resource